### PR TITLE
Do not require GORM @Entity to initialize GORM

### DIFF
--- a/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/package-info.java
+++ b/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/package-info.java
@@ -23,10 +23,8 @@
 @Configuration
 @Requires(classes = HibernateDatastore.class)
 @Requires(classes = SessionFactory.class)
-@Requires(entities = Entity.class)
 package io.micronaut.configuration.hibernate.gorm;
 
-import grails.gorm.annotation.Entity;
 import io.micronaut.context.annotation.Configuration;
 import io.micronaut.context.annotation.Requires;
 import org.grails.orm.hibernate.HibernateDatastore;


### PR DESCRIPTION
Same rationale as in https://github.com/micronaut-projects/micronaut-sql/pull/14

Do not require `@grails.gorm.annotation.Entity` to run Flyway/Liquibase migrations.