### PR TITLE
build: remove mongo-java-driver dependency

### DIFF
--- a/mongo-gorm/build.gradle
+++ b/mongo-gorm/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation "io.micronaut.configuration:micronaut-mongo-reactive:1.1.0"
     implementation "io.micronaut.configuration:micronaut-hibernate-validator:$micronautVersion"
     implementation "org.grails:grails-datastore-gorm-mongodb:$gormMongoVersion"
-    implementation "org.mongodb:mongo-java-driver:$mongoVersion"
 
     compileOnly "io.micronaut:micronaut-http-server"    
     implementation project(":runtime-groovy")


### PR DESCRIPTION
See: https://github.com/micronaut-projects/micronaut-groovy/issues/51

[micronaut-mongodb](https://github.com/micronaut-projects/micronaut-mongodb) has removed deprecated `mongo-java-driver` in version 2.x. 

This dependency does not seem to be used in `mongo-gorm`.
