### PR TITLE
Inject GORM Data Services only after all other core datastore beans have been injected

### DIFF
--- a/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/HibernateDatastoreFactory.groovy
+++ b/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/HibernateDatastoreFactory.groovy
@@ -32,6 +32,8 @@ import org.grails.orm.hibernate.connections.HibernateConnectionSource
 import org.hibernate.SessionFactory
 import org.springframework.transaction.PlatformTransactionManager
 
+import javax.inject.Named
+import javax.inject.Singleton
 import javax.sql.DataSource
 import java.util.stream.Stream
 
@@ -85,5 +87,23 @@ class HibernateDatastoreFactory {
 
         return datastore
     }
+
+    @Singleton
+    SessionFactory sessionFactory(HibernateDatastore hibernateDatastore) {
+        hibernateDatastore.getSessionFactory()
+    }
+
+    @Singleton
+    DataSource dataSource(HibernateDatastore hibernateDatastore) {
+        ((HibernateConnectionSource) hibernateDatastore.getConnectionSources().defaultConnectionSource).getDataSource()
+    }
+
+    @Primary
+    @Named("hibernate")
+    @Singleton
+    PlatformTransactionManager transactionManager(HibernateDatastore hibernateDatastore) {
+        hibernateDatastore.getTransactionManager()
+    }
+
 
 }

--- a/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/HibernateDatastoreFactory.groovy
+++ b/hibernate-gorm/src/main/groovy/io/micronaut/configuration/hibernate/gorm/HibernateDatastoreFactory.groovy
@@ -63,13 +63,6 @@ class HibernateDatastoreFactory {
             new ConfigurableEventPublisherAdapter(applicationContext),
             classes
         )
-        for (o in datastore.getServices()) {
-            applicationContext.registerSingleton(o, false)
-        }
-        for (o in datastore.getServices()) {
-            applicationContext.inject(o)
-        }
-
         return datastore
     }
 
@@ -88,5 +81,15 @@ class HibernateDatastoreFactory {
     @Singleton
     PlatformTransactionManager transactionManager(HibernateDatastore hibernateDatastore) {
         hibernateDatastore.getTransactionManager()
+    }
+
+    @Singleton
+    void setupServices(HibernateDatastore hibernateDatastore, SessionFactory sessionFactory, DataSource dataSource, PlatformTransactionManager platformTransactionManager) {
+        for (o in hibernateDatastore.getServices()) {
+            applicationContext.registerSingleton(o, false)
+        }
+        for (o in hibernateDatastore.getServices()) {
+            applicationContext.inject(o)
+        }
     }
 }

--- a/hibernate-gorm/src/test/groovy/io/micronaut/configuration/hibernate/gorm/GormConfigSpec.groovy
+++ b/hibernate-gorm/src/test/groovy/io/micronaut/configuration/hibernate/gorm/GormConfigSpec.groovy
@@ -216,6 +216,7 @@ class Book {
 abstract class BookService {
 
     @Inject DataSource dataSource
+    @Inject TransactionService transactionService
 
     @Value('${data-source.db-create}')
     String dbCreate

--- a/hibernate-gorm/src/test/groovy/io/micronaut/configuration/hibernate/gorm/GormConfigSpec.groovy
+++ b/hibernate-gorm/src/test/groovy/io/micronaut/configuration/hibernate/gorm/GormConfigSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.configuration.hibernate.gorm
 import grails.gorm.annotation.Entity
 import grails.gorm.services.Service
 import grails.gorm.transactions.TransactionService
+import io.micronaut.context.annotation.Primary
 import io.micronaut.inject.qualifiers.Qualifiers
 import org.grails.datastore.mapping.validation.ValidationException
 import org.grails.orm.hibernate.GrailsHibernateTransactionManager
@@ -31,6 +32,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import javax.annotation.PostConstruct
+import javax.inject.Inject
 import javax.inject.Singleton
 import javax.sql.DataSource
 
@@ -56,6 +58,9 @@ class GormConfigSpec extends Specification {
 
         and:
         applicationContext.containsBean(PlatformTransactionManager, Qualifiers.byName("hibernate"))
+
+        and:
+        applicationContext.containsBean(PlatformTransactionManager, Qualifiers.byStereotype(Primary))
 
         and: 'two beans: one created by the factory and the MockPlatformTransactionManager'
         applicationContext.getBeansOfType(PlatformTransactionManager).size() == 2
@@ -209,6 +214,8 @@ class Book {
 @Service(Book)
 @Singleton
 abstract class BookService {
+
+    @Inject DataSource dataSource
 
     @Value('${data-source.db-create}')
     String dbCreate


### PR DESCRIPTION
Fixes #185. 

Fixes a "chicken or the egg" problem with regards to HibernateDatastoreFactory generated beans and any GORM Data Services that might be dependent on said beans. 