### PR TITLE
Fix 3.5 branch Gradle project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.4.5'
+    id 'io.micronaut.build.shared.settings' version '5.4.10'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Gradle import fails with 
```
Could not resolve all files for configuration 'classpath'.
> Could not find null:groovydoc-gradle-plugin:null.
  Searched in the following locations:
    - https://plugins.gradle.org/m2/null/groovydoc-gradle-plugin/null/groovydoc-gradle-plugin-null.pom
    - https://repo.maven.apache.org/maven2/null/groovydoc-gradle-plugin/null/groovydoc-gradle-plugin-null.pom
  Required by:
      unspecified:unspecified:unspecified > io.micronaut.build.shared.settings:io.micronaut.build.shared.settings.gradle.plugin:5.4.5 > io.micronaut.build.internal:micronaut-build:5.4.5 > io.github.groovylang.groovydoc:io.github.groovylang.groovydoc.gradle.plugin:1.0.1
```

This is causing issues for the 3.0.x branch of groovy, which clones this branch (e.g. https://github.com/apache/groovy/actions/runs/6921739623/job/18827683288).

Upgrading `io.micronaut.build.shared.settings` seems to resolve this issue.