### PR TITLE
Upgrade micronaut to v5

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.groovy-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.groovy-module.gradle
@@ -5,6 +5,14 @@ plugins {
 
 micronautBuild {
     enableBom = false
+    descriptor {
+        parentModuleId = "io.micronaut.groovy:micronaut-runtime-groovy"
+    }
+}
+
+// Apply BOM to resolve micronaut-module-info version added by Micronaut 5 build plugin
+dependencies {
+    compileOnly platform(mn.micronaut.core.bom)
 }
 
 configurations {
@@ -15,7 +23,6 @@ dependencies {
     documentation libs.javaparser
 
     testImplementation mn.micronaut.runtime
-    testImplementation libs.groovy.test
 }
 
 groovydoc {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.groovy-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.groovy-module.gradle
@@ -5,9 +5,6 @@ plugins {
 
 micronautBuild {
     enableBom = false
-    descriptor {
-        parentModuleId = "io.micronaut.groovy:micronaut-runtime-groovy"
-    }
 }
 
 // Apply BOM to resolve micronaut-module-info version added by Micronaut 5 build plugin

--- a/function-groovy/build.gradle
+++ b/function-groovy/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'io.micronaut.build.internal.groovy-module'
 }
 
+micronautBuild {
+    descriptor {
+        parentModuleId = "io.micronaut.groovy:micronaut-function-groovy"
+    }
+}
+
 dependencies {
     compileOnly mn.micronaut.inject.groovy
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,9 @@
 [versions]
 javaparser = '3.27.1'
-micronaut-docs = "3.0.0"
-micronaut = "4.10.12"
-micronaut-test = "4.10.1"
-groovy = "4.0.18"
-spock = "2.3-groovy-4.0"
+micronaut = "5.0.0-M6"
 
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 
 javaparser = { module = 'com.github.javaparser:javaparser-core', version.ref = 'javaparser' }
-
-groovy-test = { module = 'org.apache.groovy:groovy-test', version = '' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,15 @@
 [versions]
 javaparser = '3.27.1'
-micronaut = "5.0.0-M6"
+micronaut-docs = "3.0.0"
+micronaut = "4.10.9"
+micronaut-test = "4.10.1"
+groovy = "4.0.18"
+spock = "2.3-groovy-4.0"
 
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 
 javaparser = { module = 'com.github.javaparser:javaparser-core', version.ref = 'javaparser' }
+
+groovy-test = { module = 'org.apache.groovy:groovy-test', version = '' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,9 @@
 [versions]
 javaparser = '3.27.1'
-micronaut-docs = "3.0.0"
-micronaut = "4.10.9"
-micronaut-test = "4.10.1"
-groovy = "4.0.18"
-spock = "2.3-groovy-4.0"
+micronaut = "5.0.0-M8"
 
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 
 javaparser = { module = 'com.github.javaparser:javaparser-core', version.ref = 'javaparser' }
-
-groovy-test = { module = 'org.apache.groovy:groovy-test', version = '' }

--- a/groovy-bom/build.gradle
+++ b/groovy-bom/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api platform("org.apache.groovy:groovy-bom:${libs.versions.groovy.get()}")
+    api platform("org.apache.groovy:groovy-bom:${mn.versions.groovy.get()}")
 }
 
 micronautBom {

--- a/runtime-groovy/build.gradle
+++ b/runtime-groovy/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'io.micronaut.build.internal.groovy-module'
 }
 
+micronautBuild {
+    descriptor {
+        parentModuleId = "io.micronaut.groovy:micronaut-runtime-groovy"
+    }
+}
+
 dependencies {
     api mn.groovy
 


### PR DESCRIPTION
  ## Summary
  - Upgrade Micronaut to 5.0.0-M6
  - Use groovy version from Micronaut catalog
  - Configure descriptor and BOM for Micronaut 5 build requirements

  Closes #686
